### PR TITLE
Removes default series color to use theme settings instead

### DIFF
--- a/js/build.js
+++ b/js/build.js
@@ -261,7 +261,6 @@
           series: [{
             name: data.name,
             data: data.values,
-            color: '#3276b1',
             dataLabels: {
               enabled: data.showDataValues,
               color: '#333333',


### PR DESCRIPTION
Ref. https://github.com/Fliplet/fliplet-studio/issues/2620

The `series` object had a color assigned, which is preventing the theme colors from being utilized.