### PR TITLE
Columns with empty names will be ignored when summarizing data

### DIFF
--- a/js/build.js
+++ b/js/build.js
@@ -80,7 +80,7 @@
           data.totalEntries = 6;
           return Promise.resolve()
         }
-        
+
         return Fliplet.Hooks.run('beforeQueryChart', data.dataSourceQuery).then(function() {
           return Fliplet.DataSources.fetchWithOptions(data.dataSourceQuery)
         }).then(function(result){
@@ -116,8 +116,13 @@
                       // Value is an array
                       value.forEach(function(elem) {
                         if (typeof elem === 'string') {
-                          ele = $.trim(elem);
+                          elem = $.trim(elem);
                         }
+
+                        if (!elem) {
+                          return;
+                        }
+
                         data.entries.push(elem);
                         if ( data.columns.indexOf(elem) === -1 ) {
                           data.columns.push(elem);
@@ -131,6 +136,11 @@
                       if (typeof value === 'string') {
                         value = $.trim(value);
                       }
+
+                      if (!value) {
+                        return;
+                      }
+
                       data.entries.push(value);
                       if ( data.columns.indexOf(value) === -1 ) {
                         data.columns.push(value);


### PR DESCRIPTION
@tonytlwu @squallstar

## Issue
Fliplet/fliplet-studio#4879

## Description
If the column has empty or a name that contains only spaces it will be ignored when summarizing data.

## Screenshots/screencasts
Before:
<img width="343" alt="Bar demo 2" src="https://user-images.githubusercontent.com/52824207/64523271-a4d0fb80-d304-11e9-85ca-8b4762fd4841.png">
After:
<img width="343" alt="Bar demo 1" src="https://user-images.githubusercontent.com/52824207/64523270-a4d0fb80-d304-11e9-955c-ff2ba267d740.png">

## Backward compatibility
This change is fully backward compatible.