### PR TITLE
Changing the sort order is saved after saving

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -106,4 +106,7 @@ if (data) {
   if (data.dataSourceQuery && data.dataSourceQuery.selectedModeIdx === 1) {
     $('.column-sort-order').removeClass('hidden');
   }
+  if (data.dataSortOrder) {
+    $('#select-data-sort-order').val(data.dataSortOrder);
+  }
 }


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/5264

## Description
If the user saved sorting order it will be restored after component is loaded.

## Screenshots/screencasts
![chart save demo ](https://user-images.githubusercontent.com/52824207/68998951-946b6d00-08c1-11ea-8af5-b4151ae8097f.gif)

## Backward compatibility
This change is fully backward compatible.