### PR TITLE
Adds new hooks and ensures autorefresh never stops

### DIFF
--- a/js/build.js
+++ b/js/build.js
@@ -81,10 +81,37 @@
           return Promise.resolve()
         }
 
+        // beforeQueryChart is deprecated
         return Fliplet.Hooks.run('beforeQueryChart', data.dataSourceQuery).then(function() {
-          return Fliplet.DataSources.fetchWithOptions(data.dataSourceQuery)
+          return Fliplet.Hooks.run('beforeChartQuery', {
+            config: data,
+            id: widgetId,
+            uuid: widgetUuid,
+            type: 'bar'
+          });
+        }).then(function() {
+          if (_.isFunction(data.getData)) {
+            var response = data.getData();
+
+            if (!(response instanceof Promise)) {
+              return Promise.resolve(response);
+            }
+
+            return response;
+          }
+
+          return Fliplet.DataSources.fetchWithOptions(data.dataSourceQuery);
         }).then(function(result){
-          return Fliplet.Hooks.run('afterQueryChart', result).then(function() {
+          // afterQueryChart is deprecated
+          return Fliplet.Hooks.run('afterQueryChart', result).then(function () {
+            return Fliplet.Hooks.on('afterChartQuery', {
+              config: data,
+              id: widgetId,
+              uuid: widgetUuid,
+              type: 'bar',
+              records: result
+            });
+          }).then(function () {
             data.entries = [];
             data.columns = [];
             data.values = [];
@@ -181,14 +208,24 @@
       }
 
       function getLatestData() {
-        setTimeout(function(){
-          refreshData().then(function(){
-            refreshChart();
-            if (data.autoRefresh) {
-              getLatestData();
-            }
-          });
-        }, refreshTimeout);
+        return new Promise(function (resolve, reject) {
+          setTimeout(function () {
+            refreshData().then(function () {
+              if (data.autoRefresh) {
+                getLatestData();
+              }
+
+              refreshChart();
+              resolve();
+            }).catch(function (err) {
+              if (data.autoRefresh) {
+                getLatestData();
+              }
+
+              reject(err);
+            });
+          }, refreshTimeout);
+        });
       }
 
       function drawChart() {
@@ -216,6 +253,16 @@
                 if (data.autoRefresh) {
                   getLatestData();
                 }
+              },
+              render: function () {
+                Fliplet.Hooks.run('afterChartRender', {
+                  chart: ui.flipletCharts[chartId],
+                  chartOptions: chartOpt,
+                  id: data.id,
+                  uuid: data.uuid,
+                  type: 'bar',
+                  config: data
+                });
               }
             }
           },
@@ -305,7 +352,15 @@
           }
         };
         // Create and save chart object
-        ui.flipletCharts[chartId] = new Highcharts.Chart(chartOpt);
+        Fliplet.Hooks.run('beforeChartRender', {
+          chartOptions: chartOpt,
+          id: data.id,
+          uuid: data.uuid,
+          type: 'bar',
+          config: data
+        }).then(function () {
+          ui.flipletCharts[chartId] = new Highcharts.Chart(chartOpt);
+        });
       }
 
       function redrawChart() {

--- a/js/build.js
+++ b/js/build.js
@@ -85,8 +85,8 @@
         return Fliplet.Hooks.run('beforeQueryChart', data.dataSourceQuery).then(function() {
           return Fliplet.Hooks.run('beforeChartQuery', {
             config: data,
-            id: widgetId,
-            uuid: widgetUuid,
+            id: data.id,
+            uuid: data.uuid,
             type: 'bar'
           });
         }).then(function() {
@@ -106,8 +106,8 @@
           return Fliplet.Hooks.run('afterQueryChart', result).then(function () {
             return Fliplet.Hooks.on('afterChartQuery', {
               config: data,
-              id: widgetId,
-              uuid: widgetUuid,
+              id: data.id,
+              uuid: data.uuid,
               type: 'bar',
               records: result
             });


### PR DESCRIPTION
- Adds `beforeChartRender`  and `afterChartRender` hooks https://github.com/Fliplet/fliplet-studio/issues/5357
- Adds `beforeCharQuery` and `afterChartQuery` hooks, deprecating `beforeQueryChart` and `afterQueryChart`, which does not use an object to pass data via hooks. Passing data objects via hooks makes it easier to extend with more information, allowing widget identifying information to be passed.
- Adds support for a custom `getData()` function for retrieving custom data
- Updates error handling for `getLatestData()` to ensure the autorefresh functionality doesn't stop after encountering an error https://github.com/Fliplet/fliplet-studio/issues/5615