### PR TITLE
ID-458 [Feat] Adds chart name and support for refreshing via JS API

### DIFF
--- a/interface.html
+++ b/interface.html
@@ -100,6 +100,14 @@
         </div>
       </div>
     </div>
+    <div class="form-group">
+      <div class="col-sm-4 control-label">
+        <label for="chart_name">Chart name (for JS API)</label> <a href="https://developers.fliplet.com/API/components/charts.html">Learn more</a>
+      </div>
+      <div class="col-sm-8">
+        <input type="text" class="form-control" id="chart_name" name="chart_name" placeholder="(Optional)" value="">
+      </div>
+    </div>
 
   </div>
 

--- a/js/build.js
+++ b/js/build.js
@@ -2,6 +2,8 @@
   window.ui = window.ui || {}
   ui.flipletCharts = ui.flipletCharts || {};
 
+  Fliplet.Chart = Fliplet.Widget.Namespace('chart');
+
   function init() {
     Fliplet.Widget.instance('chart-bar', function (data) {
       var chartId = data.id;
@@ -14,6 +16,11 @@
         '#474975', '#8D8EA6', '#FF5722', '#009688', '#E91E63'
       ];
       var chartInstance;
+
+      var chartReady;
+      var chartPromise = new Promise(function(resolve) {
+        chartReady = resolve;
+      });
 
       function resetData() {
         data.entries = [];
@@ -269,7 +276,7 @@
             var newColor = customColors
               ? customColors.values[colorKey]
               : Fliplet.Themes.Current.get(colorKey);
-            
+
             if (newColor) {
               colors[index] = newColor;
             }
@@ -423,6 +430,14 @@
       refreshData().then(drawChart).catch(function (error) {
         console.error(error);
         getLatestData();
+      });
+
+      Fliplet.Chart.add(chartPromise);
+
+      chartReady({
+        name: data.chartName,
+        type: 'bar',
+        refresh: getLatestData
       });
     });
   }

--- a/js/interface.js
+++ b/js/interface.js
@@ -124,6 +124,7 @@ function attachObservers() {
       chartHeightMd: $('#chart_height_md').val(),
       showDataLegend: $('#show_data_legend').is(':checked'),
       showDataValues: $('#show_data_values').is(':checked'),
+      chartName: $('#chart_name').val(),
       yAxisTitle: $('#y_axis_title').val(),
       xAxisTitle: $('#x_axis_title').val(),
       showTotalEntries: $('#show_total_entries').is(':checked'),
@@ -148,6 +149,7 @@ if (data) {
   $('#chart_height_md').val(data.chartHeightMd);
   $('#show_data_legend').prop('checked', data.showDataLegend);
   $('#show_data_values').prop('checked', data.showDataValues);
+  $('#chart_name').val(data.chartName);
   $('#y_axis_title').val(data.yAxisTitle);
   $('#x_axis_title').val(data.xAxisTitle);
   $('#show_total_entries').prop('checked', data.showTotalEntries);


### PR DESCRIPTION
Ref. https://weboo.atlassian.net/browse/ID-458

Requires https://github.com/Fliplet/fliplet-api/pull/4384

Adds support for:

```js
Fliplet.Chart.get('My chart').then(function(chart) {
  // Refresh chart
  chart.refresh();
});
```

![image](https://user-images.githubusercontent.com/290733/99992204-efc21c00-2dad-11eb-9260-fa279ca5dde9.png)
